### PR TITLE
Jdl/pde 1622 worldpay host change

### DIFF
--- a/lib/Communications.rb
+++ b/lib/Communications.rb
@@ -203,6 +203,7 @@ module CnpChargeback
 
       req = Net::HTTP::Get.new(url, CHARGEBACK_API_HEADERS)
       req.basic_auth(config_hash['user'], config_hash['password'])
+      req = set_request_headers_host(req)
 
       logger.debug "GET request to: " + url.to_s + "\n"
 
@@ -296,6 +297,18 @@ module CnpChargeback
       logger.formatter = proc { |severity, datetime, progname, msg| "#{msg}\n" }
       logger
     end
+
+    def self.set_request_headers_host(req)
+      req_headers = req.instance_variable_get('@header')
+      if !Rails.env.production?
+        req_headers["host"] = ["services.vantivprelive.com:443"]
+      else
+        req_headers["host"] = ["services.vantivcnp.com:443"]
+      end
+      req.instance_variable_set('@header', req_headers)
+      req
+    end
+
   end
 end
 


### PR DESCRIPTION
As per https://food52.atlassian.net/browse/PDE-1622

Changing the request headers `host` to `services.vantivcnp.com` / `services.vantivprelive.com` for Worldpay.